### PR TITLE
Update ldap_authentication2.src

### DIFF
--- a/check_process
+++ b/check_process
@@ -16,7 +16,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1	from_commit=49d6a9b894d17ab30fa8f972c7b08d41b9bbb2d7
 		backup_restore=1
 		multi_instance=1
 		incorrect_path=1
@@ -28,6 +27,6 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=49d6a9b894d17ab30fa8f972c7b08d41b9bbb2d7
-		name= Fix sha256sums, fix url
+	; commit=
+		name=
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&is_public=1&language=fr&password=pass&port=666&wiki_name=YnhCiMediaWiki

--- a/conf/ldap_authentication2.src
+++ b/conf/ldap_authentication2.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://extdist.wmflabs.org/dist/extensions/LDAPAuthentication2-REL1_35-771b91e.tar.gz
-SOURCE_SUM=84ddb5e871a39f4c035acec563c8b3c515cd8378aca18deab92d7b868710d882
+SOURCE_URL=https://extdist.wmflabs.org/dist/extensions/LDAPAuthentication2-REL1_35-58e281c.tar.gz
+SOURCE_SUM=1446a537b23e71cdfff9e66ef606abbee622d4582c635ab733ca71af3f9a3bee
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=false


### PR DESCRIPTION
## Problem
- Installation failed because the extension was updated and the version in the configuration was not available anymore

## Solution
- Updated the configuration file to use the latest compatible version

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** :
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/mediawiki_ynh%20PR32/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/mediawiki_ynh%20PR32/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
