### PR TITLE
update pluggable_auth.src URL and SUM

### DIFF
--- a/conf/pluggable_auth.src
+++ b/conf/pluggable_auth.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_38-919f067.tar.gz
-SOURCE_SUM=abe07553e7794d270d327839e4d21ffe90e446bd3b63b21a23878b564fb3c3fa
+SOURCE_URL=https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_39-f939f87.tar.gz
+SOURCE_SUM=157d0a6654be812581ee02728829030af76196f735bcf98b6d18818b01d06981
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=false


### PR DESCRIPTION
## Problem

- I wanted to solve the issue 79: https://github.com/YunoHost-Apps/mediawiki_ynh/issues/79

## Solution

- Fetched a newer version of the package on the mediawiki repository and updated the SHA sum
## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
